### PR TITLE
Fix base path

### DIFF
--- a/url.js
+++ b/url.js
@@ -184,7 +184,7 @@
           if (EOF == c) {
             this._host = base._host;
             this._port = base._port;
-            this._path = base._path;
+            this._path = base._path.slice();
             this._query = base._query;
             break loop;
           } else if ('/' == c || '\\' == c) {
@@ -194,13 +194,13 @@
           } else if ('?' == c) {
             this._host = base._host;
             this._port = base._port;
-            this._path = base._path;
+            this._path = base._path.slice();
             this._query = '?';
             state = 'query';
           } else if ('#' == c) {
             this._host = base._host;
             this._port = base._port;
-            this._path = base._path;
+            this._path = base._path.slice();
             this._query = base._query;
             this._fragment = '#';
             state = 'fragment';
@@ -213,7 +213,7 @@
               (EOF != nextNextC && '/' != nextNextC && '\\' != nextNextC && '?' != nextNextC && '#' != nextNextC)) {
               this._host = base._host;
               this._port = base._port;
-              this._path = base._path;
+              this._path = base._path.slice();
               this._path.pop();
             }
             state = 'relative path';

--- a/urltestharness.html
+++ b/urltestharness.html
@@ -5,8 +5,16 @@
 <script src=testharness.js></script>
 <script src=testharnessreport.js></script>
 <script src=urltestparser.js></script>
+<script>forceJURL = true;</script>
+<script src="url.js"></script>
 <div id=log></div>
 <script>
+test(function() {
+  var u = new URL('http://a/foo');
+  var u2 = new URL('bar', u);
+  assert_equals(u.href, 'http://a/foo');
+}, 'Consistency Check');
+
 var setup = async_test("Loading data…")
 setup.step(function() {
   var request = new XMLHttpRequest()


### PR DESCRIPTION
If a URL object is used for `base` argument, the `path` array is shared by the new instance, leading to mutations of the base path.

Fixed by always copying `base._path` on assignment.
