### PR TITLE
Feature check broken Webkit setters

### DIFF
--- a/url.js
+++ b/url.js
@@ -9,7 +9,8 @@
   if (!scope.forceJURL) {
     try {
       var u = new URL('b', 'http://a');
-      hasWorkingUrl = u.href === 'http://a/b';
+      u.pathname = 'c%20d';
+      hasWorkingUrl = u.href === 'http://a/c%20d';
     } catch(e) {}
   }
 


### PR DESCRIPTION
Just ran into a bug with Webkit URL setters. It doesn't seem to handle entity encodings correctly.

Reported at https://bugs.webkit.org/show_bug.cgi?id=140174

Do you think this is something this polyfill should work around and force into a "broken url" state?

Also, I'm wondering where the best place to submit tests for this is? Here or https://github.com/w3c/web-platform-tests/tree/master/url?

cc @arv @annevk